### PR TITLE
Add personal loan policy example and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Explore real-world scenarios where decision automation helps formalize and opera
 ### Finance
 - **[Expense Approval](examples/finance/expense_approval/)**  
   Multi-level approval rules and threshold-based routing using a decision table.
-
+- **[Personal Loan](examples/finance/personal_loan/)**  
+  Rules to determine Personal Loan Eligibility
+  
 ### Compliance
 - **[Anti-Money Laundering (AML)](examples/compliance/aml_policy/)**  
   Transaction pattern rules and risk classification logic.  

--- a/examples/finance/personal_loan/policy.md
+++ b/examples/finance/personal_loan/policy.md
@@ -1,0 +1,26 @@
+### **Personal Loan Policy**
+
+#### **Who Can Apply**
+
+To be considered for a personal loan, an applicant must:
+
+- Be between **21 and 65 years old**.
+- Have been **working or self-employed for at least 12 months**.
+- Earn at least **$2,000 per month**.
+- Have a **credit score of 650 or higher**.
+- Keep their **debt-to-income ratio at or below 40%**.
+- Request a loan that is **no more than 10 times their monthly income**.
+
+---
+
+#### **How Decisions Are Made**
+
+If the applicant meets all the conditions above, the application will be reviewed.
+
+- Applicants with a **credit score of 700 or more** and a **debt-to-income ratio of 30% or less** are likely to be **approved quickly**.
+
+- Applications may be **declined** if the credit score is **below 600**, the debt-to-income ratio is **above 50%**, or the applicant has **not been working for at least 12 months**.
+
+- In other cases, the application may need a **manual review**, especially if income documents are missing or unclear.
+
+---


### PR DESCRIPTION
Added a new personal loan eligibility policy example under finance and updated the README to reference this scenario. The policy outlines applicant requirements and decision criteria for personal loan applications.